### PR TITLE
Preparing the ES Embeddings Rewriter

### DIFF
--- a/src/main/java/querqy/embeddings/EmbeddingsRewriter.java
+++ b/src/main/java/querqy/embeddings/EmbeddingsRewriter.java
@@ -76,23 +76,18 @@ public class EmbeddingsRewriter extends AbstractNodeVisitor<Node> implements Que
     }
 
     protected ExpandedQuery applyEmbedding(final Embedding embedding, final ExpandedQuery inputQuery) {
-        KnnVectorQuery knnVectorQuery =  new KnnVectorQuery(vectorField, embedding.asVector(), topK);
+        KnnVectorQuery knnVectorQuery = new KnnVectorQuery(vectorField, embedding.asVector(), topK);
+        LuceneRawQuery luceneRawQuery = new LuceneRawQuery(null, Clause.Occur.MUST,true, knnVectorQuery);
 
         switch (queryMode) {
             case BOOST:
-                inputQuery.addBoostUpQuery(new BoostQuery(
-                        new LuceneRawQuery(null, Clause.Occur.SHOULD,true, knnVectorQuery),
-                        boost
-                ));
+                inputQuery.addBoostUpQuery(new BoostQuery(luceneRawQuery, boost));
                 break;
             case MAIN_QUERY:
-                inputQuery.setUserQuery(
-                        new LuceneRawQuery(null, Clause.Occur.MUST,true, knnVectorQuery)
-                );
+                inputQuery.setUserQuery(luceneRawQuery);
                 break;
             default:
                 throw new IllegalStateException("Unknown query mode: " + queryMode);
-
         }
 
         return inputQuery;

--- a/src/test/java/querqy/solr/embeddings/ChorusEmbeddingModelTest.java
+++ b/src/test/java/querqy/solr/embeddings/ChorusEmbeddingModelTest.java
@@ -1,0 +1,19 @@
+package querqy.solr.embeddings;
+
+import org.junit.Assert;
+import org.junit.Test;
+import querqy.embeddings.ChorusEmbeddingModel;
+import querqy.embeddings.Embedding;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+public class ChorusEmbeddingModelTest {
+
+    @Test
+    public void testParseJson() {
+        String embeddingJson = "{ \"embedding\": [0.3, 1, 5] }";
+        Embedding e = new ChorusEmbeddingModel().parseEmbeddingFromResponse(new ByteArrayInputStream(embeddingJson.getBytes(StandardCharsets.UTF_8)));
+        Assert.assertArrayEquals(e.asVector(), new float[] { 0.3f, 1f, 5f}, 0f);
+    }
+}


### PR DESCRIPTION
* Fixing parsing embeddings containing numbers without decimals (mostly for tests)
* Using the Lucene query for boosting directly to avoid re-parsing in ES